### PR TITLE
Reorganize key names

### DIFF
--- a/js/admin/src/main.js
+++ b/js/admin/src/main.js
@@ -6,7 +6,7 @@ app.initializers.add('flarum-flags', () => {
   extend(PermissionGrid.prototype, 'moderateItems', items => {
     items.add('viewFlags', {
       icon: 'flag',
-      label: 'View flagged posts',
+      label: app.translator.trans('flarum-flags.admin.permissions.view_flags'),
       permission: 'discussion.viewFlags'
     }, 65);
   });
@@ -14,7 +14,7 @@ app.initializers.add('flarum-flags', () => {
   extend(PermissionGrid.prototype, 'replyItems', items => {
     items.add('flagPosts', {
       icon: 'flag',
-      label: 'Flag posts',
+      label: app.translator.trans('flarum-flags.admin.permissions.flag_posts'),
       permission: 'discussion.flagPosts'
     }, 70);
   });

--- a/js/forum/src/addFlagControl.js
+++ b/js/forum/src/addFlagControl.js
@@ -10,7 +10,7 @@ export default function() {
     if (post.isHidden() || post.contentType() !== 'comment' || !post.canFlag() || post.user() === app.session.user) return;
 
     items.add('flag',
-      <Button icon="flag" onclick={() => app.modal.show(new FlagPostModal({post}))}>Flag</Button>
+      <Button icon="flag" onclick={() => app.modal.show(new FlagPostModal({post}))}>{app.translator.trans('flarum-flags.forum.post_controls.flag_button')}</Button>
     );
   });
 }

--- a/js/forum/src/addFlagsToPosts.js
+++ b/js/forum/src/addFlagsToPosts.js
@@ -65,7 +65,7 @@ export default function() {
 
     items.merge(controls);
 
-    items.add('dismiss', <Button className="Button Button--icon Button--link" icon="times" onclick={this.dismissFlag.bind(this)} title="Dismiss Flag"/>, -100);
+    items.add('dismiss', <Button className="Button Button--icon Button--link" icon="times" onclick={this.dismissFlag.bind(this)} title={app.translator.trans('flarum-flags.forum.post.dismiss_flag_tooltip')}/>, -100);
 
     return items;
   };
@@ -101,7 +101,7 @@ export default function() {
       const detail = flag.reasonDetail();
 
       return [
-        app.translator.trans(reason ? 'flarum-flags.forum.flagged_by_with_reason' : 'flarum-flags.forum.flagged_by', {user, reason}),
+        app.translator.trans(reason ? 'flarum-flags.forum.post.flagged_by_with_reason' : 'flarum-flags.forum.post.flagged_by', {user, reason}),
         detail ? <span className="Post-flagged-detail">{detail}</span> : ''
       ];
     }

--- a/js/forum/src/components/FlagList.js
+++ b/js/forum/src/components/FlagList.js
@@ -21,7 +21,7 @@ export default class FlagList extends Component {
     return (
       <div className="NotificationList FlagList">
         <div className="NotificationList-header">
-          <h4 className="App-titleControl App-titleControl--text">Flagged Posts</h4>
+          <h4 className="App-titleControl App-titleControl--text">{app.translator.trans('flarum-flags.forum.flagged_posts.title')}</h4>
         </div>
         <div className="NotificationList-content">
           <ul className="NotificationGroup-content">
@@ -50,7 +50,7 @@ export default class FlagList extends Component {
                 );
               })
               : !this.loading
-                ? <div className="NotificationList-empty">{app.translator.trans('flarum-flags.forum.no_flags')}</div>
+                ? <div className="NotificationList-empty">{app.translator.trans('flarum-flags.forum.flagged_posts.no_flags')}</div>
                 : LoadingIndicator.component({className: 'LoadingIndicator--block'})}
           </ul>
         </div>

--- a/js/forum/src/components/FlagPostModal.js
+++ b/js/forum/src/components/FlagPostModal.js
@@ -14,7 +14,7 @@ export default class FlagPostModal extends Modal {
   }
 
   title() {
-    return 'Flag Post';
+    return {app.translator.trans('flarum-flags.forum.flag_post.title')};
   }
 
   content() {
@@ -22,26 +22,26 @@ export default class FlagPostModal extends Modal {
       <div className="Modal-body">
         <div className="Form">
           <div className="Form-group">
-            <label>Choose a Reason</label>
+            <label>{app.translator.trans('flarum-flags.forum.flag_post.reason_heading')}</label>
             <div>
               <label className="checkbox">
                 <input type="radio" name="reason" checked={this.reason() === 'off_topic'} value="off_topic" onclick={m.withAttr('value', this.reason)}/>
-                Off-topic
+                {app.translator.trans('flarum-flags.forum.flag_post.reason_off_topic_label')}
               </label>
 
               <label className="checkbox">
                 <input type="radio" name="reason" checked={this.reason() === 'inappropriate'} value="inappropriate" onclick={m.withAttr('value', this.reason)}/>
-                Inappropriate
+                {app.translator.trans('flarum-flags.forum.flag_post.reason_inappropriate_label')}
               </label>
 
               <label className="checkbox">
                 <input type="radio" name="reason" checked={this.reason() === 'spam'} value="spam" onclick={m.withAttr('value', this.reason)}/>
-                Spam
+                {app.translator.trans('flarum-flags.forum.flag_post.reason_spam_label')}
               </label>
 
               <label className="checkbox">
                 <input type="radio" name="reason" checked={this.reason() === 'other'} value="other" onclick={m.withAttr('value', this.reason)}/>
-                Other
+                {app.translator.trans('flarum-flags.forum.flag_post.reason_other_label')}
                 {this.reason() === 'other' ? (
                   <textarea className="FormControl" value={this.reasonDetail()} oninput={m.withAttr('value', this.reasonDetail)}></textarea>
                 ) : ''}
@@ -55,7 +55,7 @@ export default class FlagPostModal extends Modal {
               type="submit"
               loading={this.loading}
               disabled={!this.reason()}>
-              Flag Post
+              {app.translator.trans('flarum-flags.forum.flag_post.submit_button')}
             </Button>
           </div>
         </div>

--- a/js/forum/src/components/FlagsDropdown.js
+++ b/js/forum/src/components/FlagsDropdown.js
@@ -4,7 +4,7 @@ import FlagList from 'flarum/flags/components/FlagList';
 
 export default class FlagsDropdown extends NotificationsDropdown {
   static initProps(props) {
-    props.label = props.label || 'Flagged Posts';
+    props.label = props.label || app.translator.trans('flarum-flags.forum.flagged_posts.tooltip');
     props.icon = props.icon || 'flag';
 
     super.initProps(props);


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).
- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.

Supported by [flarum/english #13](https://github.com/flarum/english/pull/13).
