### PR TITLE
Extract translation from FlagList.js

### DIFF
--- a/js/forum/src/components/FlagList.js
+++ b/js/forum/src/components/FlagList.js
@@ -39,7 +39,7 @@ export default class FlagList extends Component {
                       {avatar(post.user())}
                       {icon('flag', {className: 'Notification-icon'})}
                       <span className="Notification-content">
-                        {username(post.user())} in <em>{post.discussion().title()}</em>
+                        {app.translator.trans('flarum-flags.forum.flagged_posts.item_text', {username: username(post.user())}, {em: <em/>}, {post: post.discussion().title()})}
                       </span>
                       {humanTime(flag.time())}
                       <div className="Notification-excerpt">


### PR DESCRIPTION
- Extracts one translation used in Flags dropdown.
- Changes in English language pack to follow.
- Please check syntax before merging!

Resolves: flarum/core#931
