### PR TITLE
Change fa-times to fa-cancel

### DIFF
--- a/js/forum/src/addFlagsToPosts.js
+++ b/js/forum/src/addFlagsToPosts.js
@@ -65,7 +65,7 @@ export default function() {
 
     items.merge(controls);
 
-    items.add('dismiss', <Button className="Button Button--icon Button--link" icon="times" onclick={this.dismissFlag.bind(this)} title={app.translator.trans('flarum-flags.forum.post.dismiss_flag_tooltip')}/>, -100);
+    items.add('dismiss', <Button className="Button Button--icon Button--link" icon="ban" onclick={this.dismissFlag.bind(this)} title={app.translator.trans('flarum-flags.forum.post.dismiss_flag_tooltip')}/>, -100);
 
     return items;
   };


### PR DESCRIPTION
Mitigates confusion over button's immediate action, whether it will dismiss flag or delete post. In isolation, fa-times looks ambiguous enough to delete the post, which may delay a moderator's action when choosing how to respond. By replacing it with fa-ban, it should be immediately obvious that the action taken by the button will dismiss the flag, and not modify the post at all.
