### PR TITLE
bugfix when posts is not needed when showing discussion

### DIFF
--- a/src/Listener/AddPostFlagsRelationship.php
+++ b/src/Listener/AddPostFlagsRelationship.php
@@ -100,7 +100,9 @@ class AddPostFlagsRelationship
         // models) so that we can selectively expose only the flags that the
         // user has permission to view.
         if ($event->isController(Controller\ShowDiscussionController::class)) {
-            $posts = $event->data->getRelation('posts');
+            if ($event->data->relationLoaded('posts')) {
+                $posts = $event->data->getRelation('posts');
+            }
         }
 
         if ($event->isController(Controller\ListPostsController::class)) {


### PR DESCRIPTION
When accessing /api/discussion/[id]?include=user, NOTICE occurs