### PR TITLE
Assert registered in /api/flags to fix issue with guests

### DIFF
--- a/src/Api/Controller/ListFlagsController.php
+++ b/src/Api/Controller/ListFlagsController.php
@@ -14,11 +14,14 @@ namespace Flarum\Flags\Api\Controller;
 use Flarum\Api\Controller\AbstractListController;
 use Flarum\Flags\Api\Serializer\FlagSerializer;
 use Flarum\Flags\Flag;
+use Flarum\User\AssertPermissionTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
 class ListFlagsController extends AbstractListController
 {
+    use AssertPermissionTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -40,6 +43,8 @@ class ListFlagsController extends AbstractListController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = $request->getAttribute('actor');
+
+        $this->assertRegistered($actor);
 
         $actor->read_flags_at = time();
         $actor->save();


### PR DESCRIPTION
If a guest currently visits `/api/flags`, the following error is thrown

```php
Illuminate\Database\QueryException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'discuss.guests' doesn't exist (SQL: insert into `guests` (`read_flags_at`) values (2019-10-29 20:46:51))
...
#40 /vendor/flarum/flags/src/Api/Controller/ListFlagsController.php(45): Flarum\Flags\Api\Controller\ListFlagsController::data
#39 /vendor/flarum/core/src/Api/Controller/AbstractSerializeController.php(98): Flarum\Api\Controller\AbstractSerializeController::handle
```

I simply added an `assertRegistered` before the `read_flags_at` time is set & the user saved to the DB.

---

This is not a security vulnerability as visiting `/api/flags` as a signed-in user returns the flags that you can see (flags you created or all if you have permission to see all).