### PR TITLE
Add missing route for the flags page

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -14,6 +14,7 @@ use Flarum\Flags\Api\Controller\DeleteFlagsController;
 use Flarum\Flags\Api\Controller\ListFlagsController;
 use Flarum\Flags\Flag;
 use Flarum\Flags\Listener;
+use Flarum\Forum\Content\AssertRegistered;
 use Flarum\Post\Post;
 use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -21,7 +22,8 @@ use Illuminate\Contracts\Events\Dispatcher;
 return [
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
-        ->css(__DIR__.'/less/forum.less'),
+        ->css(__DIR__.'/less/forum.less')
+        ->route('/flags', 'flags', AssertRegistered::class),
 
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js'),


### PR DESCRIPTION
Just like notifications, flags have a page URL that's used only on mobile.

But unlike the notifications, the route was missing on the PHP side, so you end up in a 404 URL if you refresh the page on mobile while reading flags.

Tested locally.