### PR TITLE
Don't initialize cache until we receive flags

### DIFF
--- a/js/src/forum/components/FlagList.js
+++ b/js/src/forum/components/FlagList.js
@@ -13,7 +13,7 @@ export default class FlagList extends Component {
   }
 
   view() {
-    const flags = this.state.cache;
+    const flags = this.state.cache || [];
 
     return (
       <div className="NotificationList FlagList">

--- a/js/src/forum/states/FlagListState.js
+++ b/js/src/forum/states/FlagListState.js
@@ -8,8 +8,6 @@ export default class FlagListState {
      * @type {Boolean}
      */
     this.loading = false;
-
-    this.cache = [];
   }
 
   /**
@@ -17,7 +15,7 @@ export default class FlagListState {
    * been loaded.
    */
   load() {
-    if (this.cache.length && !this.app.session.user.attribute('newFlagCount')) {
+    if (this.cache && !this.app.session.user.attribute('newFlagCount')) {
       return;
     }
 


### PR DESCRIPTION
We currently get the unread count for the flags badge in navbar via:

```js
getUnreadCount() {
    return app.flags.cache ? app.flags.cache.length : app.forum.attribute('flagCount');
  }
```

But since `app.flags.cache` is initialized to `[]`, this means the count is displayed as `0` until data is loaded in (by clicking on the badge).

If we don't initialize `app.flags.cache` until results are received from API, the code works as expected.