### PR TITLE
Add Created and Deleting events

### DIFF
--- a/src/Command/CreateFlagHandler.php
+++ b/src/Command/CreateFlagHandler.php
@@ -46,6 +46,8 @@ class CreateFlagHandler
     /**
      * @param PostRepository $posts
      * @param TranslatorInterface $translator
+     * @param SettingsRepositoryInterface $settings
+     * @param Dispatcher $events
      */
     public function __construct(PostRepository $posts, TranslatorInterface $translator, SettingsRepositoryInterface $settings, Dispatcher $events)
     {

--- a/src/Command/CreateFlagHandler.php
+++ b/src/Command/CreateFlagHandler.php
@@ -9,12 +9,14 @@
 
 namespace Flarum\Flags\Command;
 
+use Flarum\Flags\Event\Created;
 use Flarum\Flags\Flag;
 use Flarum\Foundation\ValidationException;
 use Flarum\Post\CommentPost;
 use Flarum\Post\PostRepository;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Exception\PermissionDeniedException;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Symfony\Component\Translation\TranslatorInterface;
 use Tobscure\JsonApi\Exception\InvalidParameterException;
@@ -37,14 +39,20 @@ class CreateFlagHandler
     protected $settings;
 
     /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
      * @param PostRepository $posts
      * @param TranslatorInterface $translator
      */
-    public function __construct(PostRepository $posts, TranslatorInterface $translator, SettingsRepositoryInterface $settings)
+    public function __construct(PostRepository $posts, TranslatorInterface $translator, SettingsRepositoryInterface $settings, Dispatcher $events)
     {
         $this->posts = $posts;
         $this->translator = $translator;
         $this->settings = $settings;
+        $this->events = $events;
     }
 
     /**
@@ -92,6 +100,8 @@ class CreateFlagHandler
         $flag->created_at = time();
 
         $flag->save();
+
+        $this->events->dispatch(new Created($flag, $actor, $command->data));
 
         return $flag;
     }

--- a/src/Command/CreateFlagHandler.php
+++ b/src/Command/CreateFlagHandler.php
@@ -103,7 +103,7 @@ class CreateFlagHandler
 
         $flag->save();
 
-        $this->events->dispatch(new Created($flag, $actor));
+        $this->events->dispatch(new Created($flag, $actor, $data));
 
         return $flag;
     }

--- a/src/Command/CreateFlagHandler.php
+++ b/src/Command/CreateFlagHandler.php
@@ -16,7 +16,7 @@ use Flarum\Post\CommentPost;
 use Flarum\Post\PostRepository;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Exception\PermissionDeniedException;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Symfony\Component\Translation\TranslatorInterface;
 use Tobscure\JsonApi\Exception\InvalidParameterException;
@@ -103,7 +103,7 @@ class CreateFlagHandler
 
         $flag->save();
 
-        $this->events->dispatch(new Created($flag, $actor, $command->data));
+        $this->events->dispatch(new Created($flag, $actor));
 
         return $flag;
     }

--- a/src/Command/DeleteFlagsHandler.php
+++ b/src/Command/DeleteFlagsHandler.php
@@ -9,6 +9,8 @@
 
 namespace Flarum\Flags\Command;
 
+use Flarum\Flags\Event\Deleted;
+use Flarum\Flags\Event\Deleting;
 use Flarum\Flags\Event\FlagsWillBeDeleted;
 use Flarum\Flags\Flag;
 use Flarum\Post\PostRepository;
@@ -50,6 +52,10 @@ class DeleteFlagsHandler
 
         $this->events->dispatch(new FlagsWillBeDeleted($post, $actor, $command->data));
 
+        foreach ($post->flags() as $flag) {
+            $this->events->dispatch(new Deleting($flag, $actor, $command->data));
+        }
+        
         $post->flags()->delete();
 
         return $post;

--- a/src/Command/DeleteFlagsHandler.php
+++ b/src/Command/DeleteFlagsHandler.php
@@ -13,7 +13,7 @@ use Flarum\Flags\Event\Deleting;
 use Flarum\Flags\Event\FlagsWillBeDeleted;
 use Flarum\Flags\Flag;
 use Flarum\Post\PostRepository;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Events\Dispatcher;
 
 class DeleteFlagsHandler
 {
@@ -49,10 +49,11 @@ class DeleteFlagsHandler
 
         $actor->assertCan('viewFlags', $post->discussion);
 
+        // remove beta 17
         $this->events->dispatch(new FlagsWillBeDeleted($post, $actor, $command->data));
 
-        foreach ($post->flags() as $flag) {
-            $this->events->dispatch(new Deleting($flag, $actor, $command->data));
+        foreach ($post->flags as $flag) {
+            $this->events->dispatch(new Deleting($flag, $actor));
         }
 
         $post->flags()->delete();

--- a/src/Command/DeleteFlagsHandler.php
+++ b/src/Command/DeleteFlagsHandler.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Flags\Command;
 
-use Flarum\Flags\Event\Deleted;
 use Flarum\Flags\Event\Deleting;
 use Flarum\Flags\Event\FlagsWillBeDeleted;
 use Flarum\Flags\Flag;
@@ -55,7 +54,7 @@ class DeleteFlagsHandler
         foreach ($post->flags() as $flag) {
             $this->events->dispatch(new Deleting($flag, $actor, $command->data));
         }
-        
+
         $post->flags()->delete();
 
         return $post;

--- a/src/Command/DeleteFlagsHandler.php
+++ b/src/Command/DeleteFlagsHandler.php
@@ -53,7 +53,7 @@ class DeleteFlagsHandler
         $this->events->dispatch(new FlagsWillBeDeleted($post, $actor, $command->data));
 
         foreach ($post->flags as $flag) {
-            $this->events->dispatch(new Deleting($flag, $actor));
+            $this->events->dispatch(new Deleting($flag, $actor, $command->data));
         }
 
         $post->flags()->delete();

--- a/src/Event/Created.php
+++ b/src/Event/Created.php
@@ -25,19 +25,12 @@ class Created
     public $actor;
 
     /**
-     * @var array
-     */
-    public $data;
-
-    /**
      * @param Flag $flag
      * @param User $actor
-     * @param array $data
      */
-    public function __construct(Flag $flag, User $actor, array $data = [])
+    public function __construct(Flag $flag, User $actor)
     {
         $this->flag = $flag;
         $this->actor = $actor;
-        $this->data = $data;
     }
 }

--- a/src/Event/Created.php
+++ b/src/Event/Created.php
@@ -9,19 +9,15 @@
 
 namespace Flarum\Flags\Event;
 
-use Flarum\Post\Post;
+use Flarum\Flags\Flag;
 use Flarum\User\User;
 
-/** 
- * @deprecated 0.1.0-beta.16, remove 0.1.0-beta.17 
- * Listen for Flarum\Flags\Event\Deleting instead
- */
-class FlagsWillBeDeleted
+class Created
 {
     /**
-     * @var Post
+     * @var Flag
      */
-    public $post;
+    public $flag;
 
     /**
      * @var User
@@ -34,13 +30,13 @@ class FlagsWillBeDeleted
     public $data;
 
     /**
-     * @param Post $post
+     * @param Flag $flag
      * @param User $actor
      * @param array $data
      */
-    public function __construct(Post $post, User $actor, array $data = [])
+    public function __construct(Flag $flag, User $actor, array $data = [])
     {
-        $this->post = $post;
+        $this->flag = $flag;
         $this->actor = $actor;
         $this->data = $data;
     }

--- a/src/Event/Created.php
+++ b/src/Event/Created.php
@@ -25,12 +25,19 @@ class Created
     public $actor;
 
     /**
+     * @var array
+     */
+    public $data;
+
+    /**
      * @param Flag $flag
      * @param User $actor
+     * @param array $data
      */
-    public function __construct(Flag $flag, User $actor)
+    public function __construct(Flag $flag, User $actor, array $data = [])
     {
         $this->flag = $flag;
         $this->actor = $actor;
+        $this->data = $data;
     }
 }

--- a/src/Event/Deleting.php
+++ b/src/Event/Deleting.php
@@ -25,19 +25,12 @@ class Deleting
     public $actor;
 
     /**
-     * @var array
-     */
-    public $data;
-
-    /**
      * @param Flag $flag
      * @param User $actor
-     * @param array $data
      */
-    public function __construct(Flag $flag, User $actor, array $data = [])
+    public function __construct(Flag $flag, User $actor)
     {
         $this->flag = $flag;
         $this->actor = $actor;
-        $this->data = $data;
     }
 }

--- a/src/Event/Deleting.php
+++ b/src/Event/Deleting.php
@@ -9,19 +9,15 @@
 
 namespace Flarum\Flags\Event;
 
-use Flarum\Post\Post;
+use Flarum\Flags\Flag;
 use Flarum\User\User;
 
-/** 
- * @deprecated 0.1.0-beta.16, remove 0.1.0-beta.17 
- * Listen for Flarum\Flags\Event\Deleting instead
- */
-class FlagsWillBeDeleted
+class Deleting
 {
     /**
-     * @var Post
+     * @var Flag
      */
-    public $post;
+    public $flag;
 
     /**
      * @var User
@@ -34,13 +30,13 @@ class FlagsWillBeDeleted
     public $data;
 
     /**
-     * @param Post $post
+     * @param Flag $flag
      * @param User $actor
      * @param array $data
      */
-    public function __construct(Post $post, User $actor, array $data = [])
+    public function __construct(Flag $flag, User $actor, array $data = [])
     {
-        $this->post = $post;
+        $this->flag = $flag;
         $this->actor = $actor;
         $this->data = $data;
     }

--- a/src/Event/Deleting.php
+++ b/src/Event/Deleting.php
@@ -25,12 +25,19 @@ class Deleting
     public $actor;
 
     /**
+     * @var array
+     */
+    public $data;
+
+    /**
      * @param Flag $flag
      * @param User $actor
+     * @param array $data
      */
-    public function __construct(Flag $flag, User $actor)
+    public function __construct(Flag $flag, User $actor, array $data = [])
     {
         $this->flag = $flag;
         $this->actor = $actor;
+        $this->data = $data;
     }
 }

--- a/src/Event/FlagsWillBeDeleted.php
+++ b/src/Event/FlagsWillBeDeleted.php
@@ -12,7 +12,7 @@ namespace Flarum\Flags\Event;
 use Flarum\Post\Post;
 use Flarum\User\User;
 
-/** 
+/**
  * @deprecated 0.1.0-beta.16, remove 0.1.0-beta.17
  * Listen for Flarum\Flags\Event\Deleting instead
  */

--- a/src/Event/FlagsWillBeDeleted.php
+++ b/src/Event/FlagsWillBeDeleted.php
@@ -13,7 +13,7 @@ use Flarum\Post\Post;
 use Flarum\User\User;
 
 /** 
- * @deprecated 0.1.0-beta.16, remove 0.1.0-beta.17 
+ * @deprecated 0.1.0-beta.16, remove 0.1.0-beta.17
  * Listen for Flarum\Flags\Event\Deleting instead
  */
 class FlagsWillBeDeleted


### PR DESCRIPTION
Fixes flarum/core#2551

- Create two new events: `Created` and `Deleting`
- Deprecate `FlagsWillBeDeleted`

Argument for single flag per `Deleting` event:  As the `Created` event is for a single new flag, I decided it would make the most sense to also handle `Deleting` in the same, single flag at a time way. Would welcome any thoughts on how this is implemented.
