### PR TITLE
Eager load post.user.groups relation and allow extensions to eager load relations

### DIFF
--- a/src/Api/Controller/ListFlagsController.php
+++ b/src/Api/Controller/ListFlagsController.php
@@ -38,16 +38,20 @@ class ListFlagsController extends AbstractListController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = $request->getAttribute('actor');
+        $include = $this->extractInclude($request);
 
         $actor->assertRegistered();
 
         $actor->read_flags_at = time();
         $actor->save();
 
-        return Flag::whereVisibleTo($actor)
-            ->with($this->extractInclude($request))
+        $flags = Flag::whereVisibleTo($actor)
             ->latest('flags.created_at')
             ->groupBy('post_id')
             ->get();
+
+        $this->loadRelations($flags, $include);
+
+        return $flags;
     }
 }

--- a/src/Api/Controller/ListFlagsController.php
+++ b/src/Api/Controller/ListFlagsController.php
@@ -50,6 +50,10 @@ class ListFlagsController extends AbstractListController
             ->groupBy('post_id')
             ->get();
 
+        if (in_array('post.user', $include)) {
+            $include[] = 'post.user.groups';
+        }
+
         $this->loadRelations($flags, $include);
 
         return $flags;


### PR DESCRIPTION
**Part of flarum/core#2637**
**Works with flarum/core#2724**

Allows other extensions to eager load relations on its listing endpoint (like tags see **flarum/tags#125**).
Also eager loads `post.user.groups` when `post.user` is loaded, because the groups are called in policies for `isAdmin` checks.

![flarum lan___clockwork_app (5)](https://user-images.githubusercontent.com/20267363/111916149-d2f6d600-8a79-11eb-8297-b4325f10d33d.png)
![flarum lan___clockwork_app (6)](https://user-images.githubusercontent.com/20267363/111916151-d5f1c680-8a79-11eb-8df3-742a25d47406.png)
