### PR TITLE
fix: return user when creating flags

### DIFF
--- a/src/Api/Controller/CreateFlagController.php
+++ b/src/Api/Controller/CreateFlagController.php
@@ -30,7 +30,8 @@ class CreateFlagController extends AbstractCreateController
      */
     public $include = [
         'post',
-        'post.flags'
+        'post.flags',
+        'user'
     ];
 
     /**


### PR DESCRIPTION
Fixes https://github.com/flarum/QualityAssurance/issues/41

When the API response is ingested by `pushObject`, since the flag instance is new, there is nothing to merge with, and therefore, there's no user on the flag instance in the store. As a result, the flag is displayed with "deleted" as the creating user until a page refresh occurs.

More broadly, this could be fixed by either:
- Refactoring the JSON API layer so that all singular operations return the same set of includes.
- Merging the API Paylod with sent data on model save (for new instances only).
But the former would require a major breaking rewrite, and the latter could introduce potentially unwanted side effects, and is effectively a bandaid over inconsistent backend behavior.